### PR TITLE
feat: migrate backend OAuth secret from Secrets Manager to SSM

### DIFF
--- a/src/Backend/ChaosRecipeEnhancer.Backend.TokenRetreivalHandler.V2/app.mjs
+++ b/src/Backend/ChaosRecipeEnhancer.Backend.TokenRetreivalHandler.V2/app.mjs
@@ -1,49 +1,37 @@
 /* global fetch, btoa, atob */
 
-import {
-  SecretsManagerClient,
-  GetSecretValueCommand,
-} from "@aws-sdk/client-secrets-manager";
+import { SSMClient, GetParametersCommand } from "@aws-sdk/client-ssm";
 
-/**
- * This Lambda function retrieves an authentication token from the Path of Exile API.
- * It first retrieves the client secret from AWS Secrets Manager, then uses it along with the
- * provided code and code_verifier to obtain the token.
- */
+const getOAuthCredentials = async () => {
+  const client = new SSMClient({ region: "us-east-1" });
 
-/* This uses the AWS Secrets Manager to get the secret key for the GGGAUTH API. */
-/* Docs: https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets_lambda.html */
-const getClientSecret = async () => {
-  const client = new SecretsManagerClient({
-    region: "us-east-1",
-  });
+  const response = await client.send(
+    new GetParametersCommand({
+      Names: ["/CRE/GGGAuth/clientId", "/CRE/GGGAuth/clientSecret"],
+      WithDecryption: true,
+    })
+  );
 
-  let response;
-
-  try {
-    const secretName = "CRE/Secrets/GGGAuth";
-    response = await client.send(
-      new GetSecretValueCommand({
-        SecretId: secretName,
-        VersionStage: "AWSCURRENT", // VersionStage defaults to AWSCURRENT if unspecified
-      })
+  if (response.InvalidParameters && response.InvalidParameters.length > 0) {
+    throw new Error(
+      `Missing SSM parameters: ${response.InvalidParameters.join(", ")}`
     );
-  } catch (error) {
-    // For a list of exceptions thrown, see
-    // https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
-    throw error;
   }
 
-  const secretsJson = response.SecretString;
-  const parsedJson = JSON.parse(secretsJson); // Parse the entire JSON string
-  const clientSecret = parsedJson.clientSecret; // Extract the clientSecret
+  const byName = Object.fromEntries(
+    response.Parameters.map((p) => [p.Name, p.Value])
+  );
 
-  return clientSecret;
+  return {
+    clientId: byName["/CRE/GGGAuth/clientId"],
+    clientSecret: byName["/CRE/GGGAuth/clientSecret"],
+  };
 };
 
 /**
  * Retrieves the authentication token from the Path of Exile API.
  * @param {Object} params - Parameters required for the token request.
+ * @param {string} params.clientId - The OAuth client id.
  * @param {string} params.secretKey - The client secret key.
  * @param {string} params.code - The authorization code.
  * @param {string} params.codeVerifier - The code verifier string.
@@ -51,6 +39,7 @@ const getClientSecret = async () => {
  * @returns {Promise<Object>} The token response JSON.
  */
 const getAuthToken = async ({
+  clientId,
   secretKey,
   code,
   codeVerifier,
@@ -65,7 +54,7 @@ const getAuthToken = async ({
   }
 
   const urlencodedParams = new URLSearchParams();
-  urlencodedParams.append("client_id", "chaosrecipeenhancer");
+  urlencodedParams.append("client_id", clientId);
   urlencodedParams.append("client_secret", secretKey);
   urlencodedParams.append("grant_type", "authorization_code");
   urlencodedParams.append("code", code);
@@ -124,7 +113,7 @@ export const handler = async (event, context) => {
       `handler --- Incoming Headers: ${JSON.stringify(event.headers)}`
     );
 
-    const secretKey = await getClientSecret();
+    const { clientId, clientSecret } = await getOAuthCredentials();
     const params = new URLSearchParams(atob(event.body));
     const code = params.get("code");
     const codeVerifier = params.get("code_verifier");
@@ -148,7 +137,8 @@ export const handler = async (event, context) => {
         "OAuth,chaosrecipeenhancer/TokenRetrievalV2Backend,(contact: dev@chaos-recipe.com)"; // Default
 
     const token = await getAuthToken({
-      secretKey,
+      clientId,
+      secretKey: clientSecret,
       code,
       codeVerifier,
       userAgent,

--- a/src/Backend/deploy.sh
+++ b/src/Backend/deploy.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# deploy.sh — repeatable deploy for the CRE backend Lambda functions.
+#
+# The backend has no IaC; each function is a single-file handler. AWS expects the
+# entry point at index.handler, but in this repo the source file is named app.mjs.
+# This script packages <handler-dir>/app.mjs as index.mjs and pushes it via
+# `aws lambda update-function-code`.
+#
+# The Node.js 20 Lambda runtime already provides @aws-sdk/* (Secrets Manager, SSM,
+# etc.), so no node_modules bundling is required.
+#
+# Written for portability against bash 3.2 (the default on macOS) — no associative
+# arrays.
+#
+# Usage:
+#   ./deploy.sh v2           # deploy TokenRetreivalHandler.V2 -> CRE-Backend-V2-TokenRetrievalHandler
+#   ./deploy.sh redirect     # deploy RedirectionHandler       -> CRE-Backend-RedirectionHandler
+#   ./deploy.sh all          # deploy all live functions
+#
+# Env overrides:
+#   AWS_REGION   (default: us-east-1)
+#   DRY_RUN=1    package only, do not upload
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+resolve_src_dir() {
+  case "$1" in
+    v2)       echo "ChaosRecipeEnhancer.Backend.TokenRetreivalHandler.V2" ;;
+    redirect) echo "ChaosRecipeEnhancer.Backend.RedirectionHandler" ;;
+    *)        return 1 ;;
+  esac
+}
+
+resolve_fn_name() {
+  case "$1" in
+    v2)       echo "CRE-Backend-V2-TokenRetrievalHandler" ;;
+    redirect) echo "CRE-Backend-RedirectionHandler" ;;
+    *)        return 1 ;;
+  esac
+}
+
+deploy_one() {
+  key="$1"
+  src_dir="$(resolve_src_dir "$key")" || { echo "ERROR: unknown target '$key' (valid: v2 redirect all)" >&2; exit 1; }
+  fn_name="$(resolve_fn_name "$key")"
+  src_file="$SCRIPT_DIR/$src_dir/app.mjs"
+
+  if [ ! -f "$src_file" ]; then
+    echo "ERROR: source file not found: $src_file" >&2
+    exit 1
+  fi
+
+  workdir="$(mktemp -d)"
+  zip="$(mktemp -u).zip"
+
+  # AWS entry point is index.handler; rename app.mjs -> index.mjs
+  cp "$src_file" "$workdir/index.mjs"
+  ( cd "$workdir" && zip -q -r "$zip" index.mjs )
+
+  echo "==> $key: packaged $src_dir/app.mjs as index.mjs ($(wc -c < "$zip" | tr -d ' ') bytes)"
+
+  if [ "${DRY_RUN:-0}" = "1" ]; then
+    echo "    DRY_RUN=1 — skipping upload to $fn_name"
+    rm -rf "$workdir" "$zip"
+    return 0
+  fi
+
+  echo "    Uploading to Lambda function: $fn_name (region: $REGION)"
+  aws lambda update-function-code \
+    --region "$REGION" \
+    --function-name "$fn_name" \
+    --zip-file "fileb://$zip" \
+    --publish \
+    --query '{Function:FunctionName,Version:Version,LastModified:LastModified,CodeSize:CodeSize}' \
+    --output table
+
+  rm -rf "$workdir" "$zip"
+}
+
+main() {
+  if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <v2|redirect|all>" >&2
+    exit 1
+  fi
+
+  if [ "$1" = "all" ]; then
+    for k in v2 redirect; do
+      deploy_one "$k"
+    done
+  else
+    deploy_one "$1"
+  fi
+
+  echo "Done."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Replaces AWS Secrets Manager with SSM SecureString parameters for the GGG OAuth credentials, eliminating the ~\$0.40/mo Secrets Manager charge (SSM Standard tier is free). Also adds the backend's first repeatable Lambda deploy tooling and removes dead resources.

This came out of a cost review of the AWS account — the infra was already very lean (~\$1/mo), and Secrets Manager was the one recurring line with a clean free alternative.

## Code changes (this PR)

- **`V2/app.mjs`**: swap `@aws-sdk/client-secrets-manager` → `@aws-sdk/client-ssm`. Reads `/CRE/GGGAuth/clientId` + `/CRE/GGGAuth/clientSecret` via `GetParameters` (`WithDecryption`), with an invalid-parameter guard. `client_id` is now sourced from SSM instead of being hardcoded.
- **`src/Backend/deploy.sh`** (new): repeatable deploy tooling — the backend previously had no deploy mechanism (hand-uploaded via console). Packages `app.mjs` as `index.mjs` (matching the Lambda `index.handler` entry point) and pushes via `aws lambda update-function-code`. Supports `v2|redirect|all` and `DRY_RUN=1`. Portable to bash 3.2 (macOS default).

## Infra changes (applied out-of-band, not in repo)

- Created SSM SecureString params from the existing secret value (`alias/aws/ssm` KMS key, Standard tier)
- **IAM tightening**: replaced the over-broad `SecretsManagerReadWrite` managed policy (which granted `*` read/write on ALL secrets) with a least-privilege inline policy — `ssm:GetParameters` on the two exact param ARNs + `kms:Decrypt` restricted to `ssm.us-east-1.amazonaws.com`
- Deleted the dead v1 `CRE-Backend-TokenRetrievalHandler` (0 invocations/30d), its unused `POST /auth/token` route, and an orphaned API GW integration pointing at a deleted `RefreshTokenHandler`
- Scheduled deletion of secret `CRE/Secrets/GGGAuth` (7-day recovery window)

## Verification

Deployed to `CRE-Backend-V2-TokenRetrievalHandler` and tested end-to-end **both before and after** removing Secrets Manager access:
- Credentials fetch from SSM successfully (KMS decrypt works via the scoped policy)
- Request reaches the live GGG token endpoint, which returns `invalid_grant` only because the test used a fake auth code — confirming the full credential path works

## Notes

- The `v1` deploy target was removed from `deploy.sh` since that function no longer exists.
- No version bump needed (backend-only infra change).